### PR TITLE
Add PHP7 to TravisCI configuration

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# set -e
+
+if [ "$TRAVIS_PHP_VERSION" = "7.0" ]; then
+	git clone -b phpseven https://github.com/mkoppanen/imagick.git
+	cd imagick
+	phpize
+	./configure --prefix=$HOME/.phpenv/versions/$(phpenv version-name)
+	make
+	make install
+	echo "extension = imagick.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+	cd ..
+elif [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then
+	printf "\n" | pecl install imagick
+fi
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: php
 
-# We want to test against PHP 5.3/5.4/5.5/5.6
 php:
   - 5.3
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
 
 env:
@@ -23,19 +23,21 @@ matrix:
         - PHPCS=1
     - php: hhvm
 
-before_script:
+before_install:
   - uname -a
   - date
-  - composer self-update
-  - composer install
-  - if [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then printf "\n" | pecl install imagick; fi;
-  - if [ "$PHPCS" == 1 ]; then pyrus install pear/PHP_CodeSniffer; fi;
+
+install: ./.travis.sh
+
+before_script:
+  - travis_retry composer self-update
+  - travis_retry composer install
   - phpenv rehash
 
 script:
-  - if [ "$PHPCS" == 1 ]; then phpcs --standard=psr2 lib/ tests/; exit $?; fi;
-  - cd tests
-  - phpunit --coverage-text
+  - if [ "$PHPCS" == 1 ]; then ./vendor/bin/phpcs --standard=psr2 lib/ tests/; exit $?; fi;
+  - phpunit -c tests --coverage-text
 
 notifications:
   email: false
+

--- a/lib/ColorThief/VBox.php
+++ b/lib/ColorThief/VBox.php
@@ -89,7 +89,7 @@ class VBox
                 for ($j = $this->g1; $j <= $this->g2; $j++) {
                     for ($k = $this->b1; $k <= $this->b2; $k++) {
                         $histoindex = ColorThief::getColorIndex($i, $j, $k);
-                        $hval = isset ($this->histo[$histoindex]) ? $this->histo[$histoindex] : 0;
+                        $hval = isset($this->histo[$histoindex]) ? $this->histo[$histoindex] : 0;
                         $ntot += $hval;
                         $rsum += ($hval * ($i + 0.5) * $mult);
                         $gsum += ($hval * ($j + 0.5) * $mult);


### PR DESCRIPTION
There isn't a released version of imagick with PHP7 support, so here I compile it from the git branch. Change to VBox.php was a phpcs fix. phpcs is being installed via composer, so it shouldn't be necessary to install it with pyrus.