### PR TITLE
Improve performance of image loading and histogram creation.

### DIFF
--- a/lib/ColorThief/VBox.php
+++ b/lib/ColorThief/VBox.php
@@ -47,7 +47,7 @@ class VBox
             if ($this->volume() > count($this->histo)) {
                 // Iterate over the histogram if the size of this histogram is lower than the vbox volume
                 foreach ($this->histo as $rgb => $count) {
-                    $rgb_array = ColorThief::getColorsFromIndex($rgb, 0, ColorThief::SIGBITS);
+                    $rgb_array = ColorThief::getColorsFromIndex($rgb);
                     if ($this->contains($rgb_array, 0)) {
                         $npix += $count;
                     }
@@ -81,7 +81,6 @@ class VBox
     {
         if (!$this->avg || $force) {
             $ntot = 0;
-            $mult = 1 << (8 - ColorThief::SIGBITS);
             $rsum = 0;
             $gsum = 0;
             $bsum = 0;
@@ -92,9 +91,9 @@ class VBox
                         $histoindex = ColorThief::getColorIndex($i, $j, $k);
                         $hval = isset($this->histo[$histoindex]) ? $this->histo[$histoindex] : 0;
                         $ntot += $hval;
-                        $rsum += ($hval * ($i + 0.5) * $mult);
-                        $gsum += ($hval * ($j + 0.5) * $mult);
-                        $bsum += ($hval * ($k + 0.5) * $mult);
+                        $rsum += ($hval * ($i + 0.5));
+                        $gsum += ($hval * ($j + 0.5));
+                        $bsum += ($hval * ($k + 0.5));
                     }
                 }
             }
@@ -108,9 +107,9 @@ class VBox
             } else {
                 // echo 'empty box'."\n";
                 $this->avg = [
-                    (int) ($mult * ($this->r1 + $this->r2 + 1) / 2),
-                    (int) ($mult * ($this->g1 + $this->g2 + 1) / 2),
-                    (int) ($mult * ($this->b1 + $this->b2 + 1) / 2),
+                    (int) (($this->r1 + $this->r2 + 1) / 2),
+                    (int) (($this->g1 + $this->g2 + 1) / 2),
+                    (int) (($this->b1 + $this->b2 + 1) / 2),
                 ];
 
                 // Ensure all channel values are leather or equal 255 (Issue #24)

--- a/lib/ColorThief/VBox.php
+++ b/lib/ColorThief/VBox.php
@@ -46,20 +46,21 @@ class VBox
             // the number of pixels contained in this vbox.
             if ($this->volume() > count($this->histo)) {
                 // Iterate over the histogram if the size of this histogram is lower than the vbox volume
-                foreach ($this->histo as $rgb => $count) {
-                    $rgb_array = ColorThief::getColorsFromIndex($rgb);
-                    if ($this->contains($rgb_array, 0)) {
+                foreach ($this->histo as $bucketInt => $count) {
+                    $rgbBuckets = ColorThief::getColorsFromIndex($bucketInt, 0, ColorThief::SIGBITS);
+                    if ($this->contains($rgbBuckets, 0)) {
                         $npix += $count;
                     }
                 }
             } else {
                 // Or iterate over points of the vbox if the size of the histogram is greater than the vbox volume
-                for ($i = $this->r1; $i <= $this->r2; $i++) {
-                    for ($j = $this->g1; $j <= $this->g2; $j++) {
-                        for ($k = $this->b1; $k <= $this->b2; $k++) {
-                            $index = ColorThief::getColorIndex($i, $j, $k);
-                            if (isset($this->histo[$index])) {
-                                $npix += $this->histo[$index];
+                for ($redBucket = $this->r1; $redBucket <= $this->r2; $redBucket++) {
+                    for ($greenBucket = $this->g1; $greenBucket <= $this->g2; $greenBucket++) {
+                        for ($blueBucket = $this->b1; $blueBucket <= $this->b2; $blueBucket++) {
+                            // The getColorIndex function takes RGB values instead of buckets. The left shift converts our bucket into its RGB value.
+                            $bucketInt = ColorThief::getColorIndex($redBucket << ColorThief::RSHIFT, $greenBucket << ColorThief::RSHIFT, $blueBucket << ColorThief::RSHIFT, ColorThief::SIGBITS);
+                            if (isset($this->histo[$bucketInt])) {
+                                $npix += $this->histo[$bucketInt];
                             }
                         }
                     }
@@ -77,23 +78,32 @@ class VBox
         return new self($this->r1, $this->r2, $this->g1, $this->g2, $this->b1, $this->b2, $this->histo);
     }
 
+    /**
+     * Calculates the average color represented by this VBox.
+     *
+     * @param bool $force
+     * @return array|bool
+     */
     public function avg($force = false)
     {
         if (!$this->avg || $force) {
             $ntot = 0;
+            $mult = 1 << ColorThief::RSHIFT;
             $rsum = 0;
             $gsum = 0;
             $bsum = 0;
 
-            for ($i = $this->r1; $i <= $this->r2; $i++) {
-                for ($j = $this->g1; $j <= $this->g2; $j++) {
-                    for ($k = $this->b1; $k <= $this->b2; $k++) {
-                        $histoindex = ColorThief::getColorIndex($i, $j, $k);
-                        $hval = isset($this->histo[$histoindex]) ? $this->histo[$histoindex] : 0;
+            for ($redBucket = $this->r1; $redBucket <= $this->r2; $redBucket++) {
+                for ($greenBucket = $this->g1; $greenBucket <= $this->g2; $greenBucket++) {
+                    for ($blueBucket = $this->b1; $blueBucket <= $this->b2; $blueBucket++) {
+                        // getColorIndex takes RGB values instead of buckets, so left shift so we get a bucketInt
+                        $bucketInt = ColorThief::getColorIndex($redBucket<<3, $greenBucket<<3, $blueBucket<<3, ColorThief::SIGBITS);
+
+                        $hval = isset($this->histo[$bucketInt]) ? $this->histo[$bucketInt] : 0;
                         $ntot += $hval;
-                        $rsum += ($hval * ($i + 0.5));
-                        $gsum += ($hval * ($j + 0.5));
-                        $bsum += ($hval * ($k + 0.5));
+                        $rsum += ($hval * ($redBucket + 0.5) * $mult);
+                        $gsum += ($hval * ($greenBucket + 0.5) * $mult);
+                        $bsum += ($hval * ($blueBucket + 0.5) * $mult);
                     }
                 }
             }
@@ -107,9 +117,9 @@ class VBox
             } else {
                 // echo 'empty box'."\n";
                 $this->avg = [
-                    (int) (($this->r1 + $this->r2 + 1) / 2),
-                    (int) (($this->g1 + $this->g2 + 1) / 2),
-                    (int) (($this->b1 + $this->b2 + 1) / 2),
+                    (int) ($mult * ($this->r1 + $this->r2 + 1) / 2),
+                    (int) ($mult * ($this->g1 + $this->g2 + 1) / 2),
+                    (int) ($mult * ($this->b1 + $this->b2 + 1) / 2),
                 ];
 
                 // Ensure all channel values are leather or equal 255 (Issue #24)

--- a/tests/ColorThiefTest.php
+++ b/tests/ColorThiefTest.php
@@ -349,26 +349,6 @@ class ColorThiefTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testGetHisto()
-    {
-        $method = new \ReflectionMethod('\ColorThief\ColorThief', 'getHisto');
-        $method->setAccessible(true);
-
-        // [[229, 210, 51], [133, 24, 135], [216, 235, 108], [132, 25, 134], [223, 46, 29],
-        // [135, 28, 132], [233, 133, 213], [225, 212, 48]]
-        $pixels = [15061555, 8722567, 14216044, 8657286, 14626333, 8854660, 15304149, 14799920];
-
-        $expectedHisto = [
-            29510 => 2,
-            16496 => 3,
-            28589 => 1,
-            27811 => 1,
-            30234 => 1,
-        ];
-
-        $this->assertSame($expectedHisto, $method->invoke(null, $pixels));
-    }
-
     public function testVboxFromPixels()
     {
         $method = new \ReflectionMethod('\ColorThief\ColorThief', 'vboxFromHistogram');


### PR DESCRIPTION
Create the histogram while looping through the image pixels.  The pixelArray is not used except for creating the histogram, so don't bother saving the pixels now that it creates the histogram directly.  This improves speed somewhat and saves a decent amount of memory when loading images using $quality of 1 pixel.