### PR TITLE
Support GdImage in PHP 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "ksubileau/color-thief-php",
+    "name": "agapanthus/color-thief-php",
     "type": "library",
     "homepage" : "http://www.kevinsubileau.fr/projets/color-thief-php",
     "description": "Grabs the dominant color or a representative color palette from an image.",

--- a/lib/ColorThief/Image/Adapter/GDImageAdapter.php
+++ b/lib/ColorThief/Image/Adapter/GDImageAdapter.php
@@ -9,7 +9,8 @@ class GDImageAdapter extends ImageAdapter
      */
     public function load($resource)
     {
-        if (!is_resource($resource) || get_resource_type($resource) != 'gd') {
+        if ((!is_resource($resource) || get_resource_type($resource) != 'gd') 
+            && get_class($resource) != "GdImage") {
             throw new \InvalidArgumentException('Passed variable is not a valid GD resource');
         }
 

--- a/lib/ColorThief/Image/ImageLoader.php
+++ b/lib/ColorThief/Image/ImageLoader.php
@@ -37,7 +37,8 @@ class ImageLoader
                 $image->loadFile($source);
             }
         } else {
-            if ((is_resource($source) && get_resource_type($source) == 'gd')) {
+            if ((is_resource($source) && get_resource_type($source) == 'gd')
+                || get_class($source) == "GdImage") {
                 $image = $this->getAdapter('GD');
             } elseif (is_a($source, 'Imagick')) {
                 $image = $this->getAdapter('Imagick');


### PR DESCRIPTION
In PHP 8.0 `is_resource` returns false for instances of GdImage. Instead, `get_class($resource) == "GdImage"` can be used.
See [php.watch](https://php.watch/versions/8.0/gdimage).